### PR TITLE
Translate BAG 'kantoorfunctie' attribute to OSM tag building=office.

### DIFF
--- a/src/main/java/org/openstreetmap/josm/plugins/ods/bag/osm/BagBuildingPrimitiveBuilder.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/ods/bag/osm/BagBuildingPrimitiveBuilder.java
@@ -73,7 +73,7 @@ public class BagBuildingPrimitiveBuilder extends BagPrimitiveBuilder<BagBuilding
                 type = "retail";
                 break;
             case "kantoorfunctie":
-                type = "commercial";
+                type = "office";
                 break;
             default: 
                 type = "yes";

--- a/src/main/java/org/openstreetmap/josm/plugins/ods/bag/osm/BagBuildingPrimitiveBuilder.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/ods/bag/osm/BagBuildingPrimitiveBuilder.java
@@ -118,7 +118,7 @@ public class BagBuildingPrimitiveBuilder extends BagPrimitiveBuilder<BagBuilding
                 type = "retail";
                 break;
             case "kantoorfunctie":
-                type = "commercial";
+                type = "office";
                 break;
             default:
                 type = "yes";


### PR DESCRIPTION
Previously 'kantoorfunctie' was translated to building=commercial which was
deemed inappropriate in too many occasions.

See for reference the discussion on the OSM forum:
[BAG Gemeentehuis e.d. als building=commercial?](http://forum.openstreetmap.org/viewtopic.php?id=25249)
