### PR TITLE
Omgaan met tekortkomingen in BAG-huisnummernotatie

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@
 /target
 /build
 /dist
+
+# IDE stuff
+.idea
+**.iml

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,6 @@
   <artifactId>josm-ods-bag</artifactId>
   <version>0.6.17</version>
   <build>
-    <sourceDirectory>src</sourceDirectory>
     <plugins>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
@@ -15,18 +14,40 @@
           <target />
         </configuration>
       </plugin>
+
+      <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>2.22.2</version>
+      </plugin>
     </plugins>
   </build>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
+
+    <junit.jupiter.version>5.5.2</junit.jupiter.version>
+    <mockito.version>3.2.4</mockito.version>
   </properties>
   <dependencies>
     <dependency>
       <groupId>josm-plugins</groupId>
       <artifactId>opendataservices</artifactId>
       <version>0.6.17</version>
+    </dependency>
+
+    <!-- Testing dependencies. -->
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <version>${junit.jupiter.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-junit-jupiter</artifactId>
+      <version>3.2.4</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 </project>

--- a/src/main/java/org/openstreetmap/josm/plugins/ods/bag/osm/build/BagAddressNodeEntityPrimitiveBuilder.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/ods/bag/osm/build/BagAddressNodeEntityPrimitiveBuilder.java
@@ -2,6 +2,7 @@ package org.openstreetmap.josm.plugins.ods.bag.osm.build;
 
 import java.util.Map;
 
+import org.openstreetmap.josm.plugins.ods.bag.osm.build.address.AddressConversionAlgorithms;
 import org.openstreetmap.josm.plugins.ods.domains.buildings.OdAddressNode;
 import org.openstreetmap.josm.plugins.ods.entities.opendata.OdLayerManager;
 
@@ -12,9 +13,9 @@ public class BagAddressNodeEntityPrimitiveBuilder extends BagEntityPrimitiveBuil
     }
 
     @Override
-    protected void buildTags(OdAddressNode addresNode, Map<String, String> tags) {
-        createAddressTags(addresNode.getAddress(), tags);
+    protected void buildTags(OdAddressNode addressNode, Map<String, String> tags) {
+        AddressConversionAlgorithms.bagToOsm(addressNode.getAddress(), tags::put);
         tags.put("source", "BAG");
-        tags.put("source:date", addresNode.getSourceDate());
+        tags.put("source:date", addressNode.getSourceDate());
     }
 }

--- a/src/main/java/org/openstreetmap/josm/plugins/ods/bag/osm/build/BagBuildingEntityPrimitiveBuilder.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/ods/bag/osm/build/BagBuildingEntityPrimitiveBuilder.java
@@ -1,11 +1,12 @@
 package org.openstreetmap.josm.plugins.ods.bag.osm.build;
 
-import java.util.Map;
-
+import org.openstreetmap.josm.plugins.ods.bag.osm.build.address.AddressConversionAlgorithms;
 import org.openstreetmap.josm.plugins.ods.domains.buildings.OdAddress;
 import org.openstreetmap.josm.plugins.ods.domains.buildings.OdBuilding;
 import org.openstreetmap.josm.plugins.ods.entities.EntityStatus;
 import org.openstreetmap.josm.plugins.ods.entities.opendata.OdLayerManager;
+
+import java.util.Map;
 
 public class BagBuildingEntityPrimitiveBuilder extends BagEntityPrimitiveBuilder<OdBuilding> {
 
@@ -28,9 +29,8 @@ public class BagBuildingEntityPrimitiveBuilder extends BagEntityPrimitiveBuilder
     @Override
     protected void buildTags(OdBuilding building, Map<String, String> tags) {
         OdAddress address = building.getAddress();
-        if (address != null) {
-            createAddressTags(address, tags);
-        }
+        AddressConversionAlgorithms.bagToOsm(address, tags::put);
+
         tags.put("source", "BAG");
         tags.put("source:date", building.getSourceDate());
         tags.put("ref:bag", building.getReferenceId().toString());

--- a/src/main/java/org/openstreetmap/josm/plugins/ods/bag/osm/build/BagEntityPrimitiveBuilder.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/ods/bag/osm/build/BagEntityPrimitiveBuilder.java
@@ -33,20 +33,4 @@ implements EntityPrimitiveBuilder<T> {
     }
 
     protected abstract void buildTags(T entity, Map<String, String> tags);
-
-    public static void createAddressTags(OdAddress address, Map<String, String> tags) {
-        if (address.getStreetName() != null) {
-            tags.put("addr:street", address.getStreetName());
-        }
-        if (address.getFullHouseNumber() != null) {
-            tags.put("addr:housenumber", address.getFullHouseNumber());
-        }
-        if (address.getPostcode() != null) {
-            tags.put("addr:postcode", address.getPostcode());
-        }
-        if (address.getCityName() != null) {
-            tags.put("addr:city", address.getCityName());
-        }
-    }
-
 }

--- a/src/main/java/org/openstreetmap/josm/plugins/ods/bag/osm/build/address/AddressConversionAlgorithms.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/ods/bag/osm/build/address/AddressConversionAlgorithms.java
@@ -1,0 +1,53 @@
+package org.openstreetmap.josm.plugins.ods.bag.osm.build.address;
+
+import org.openstreetmap.josm.plugins.ods.bag.osm.build.address.converters.Generiek;
+import org.openstreetmap.josm.plugins.ods.bag.osm.build.address.converters.Voorloopletter;
+import org.openstreetmap.josm.plugins.ods.domains.buildings.OdAddress;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.BiConsumer;
+
+/**
+ * Convert an address from the BAG to OSM address tags. This is usually straight forward, but to handle exceptions
+ * (e.g., where the BAG data is wrongly formatted), this class can be extended by implementing {@link AddressConverter}
+ * and adding the converter to the service-loader.
+ */
+public class AddressConversionAlgorithms {
+    public static final String ADDR_STREET = "addr:street";
+    public static final String ADDR_HOUSENUMBER = "addr:housenumber";
+    public static final String ADDR_POSTCODE = "addr:postcode";
+    public static final String ADDR_CITY = "addr:city";
+
+    static List<AddressConverter> converters;
+
+    static {
+        // The order of converters matters. The first applicable converter for an address will be called.
+        converters = Arrays.asList(
+
+                new Voorloopletter(),
+
+                // Catch-all. This one should always be the last in the list.
+                new Generiek()
+
+        );
+    }
+
+    /**
+     * Convert a BAG address to OSM tags.
+     *
+     * @param address   BAG address. May be {@code null} (no tags will be set in that case).
+     * @param tagSetter Will be called for each tag to set.
+     */
+    public static void bagToOsm(OdAddress address, BiConsumer<String, String> tagSetter) {
+        if (address == null) return;
+        if (tagSetter == null) throw new IllegalArgumentException("No tagSetter provided.");
+
+        converters.stream()
+                .filter(converter -> converter.isApplicable(address))
+                .findFirst()
+                // Not possible if Generiek is present in the list.
+                .orElseThrow(RuntimeException::new)
+                .bagToOsm(address, tagSetter);
+    }
+}

--- a/src/main/java/org/openstreetmap/josm/plugins/ods/bag/osm/build/address/AddressConverter.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/ods/bag/osm/build/address/AddressConverter.java
@@ -1,0 +1,26 @@
+package org.openstreetmap.josm.plugins.ods.bag.osm.build.address;
+
+import org.openstreetmap.josm.plugins.ods.domains.buildings.OdAddress;
+
+import java.util.function.BiConsumer;
+
+/**
+ * Converts BAG addresses to OSM address tags.
+ */
+public interface AddressConverter {
+    /**
+     * Check if this converter can be used for this address.
+     *
+     * @param address BAG address.
+     * @return True if this class can perform the conversion.
+     */
+    boolean isApplicable(OdAddress address);
+
+    /**
+     * Perform the conversion.
+     *
+     * @param address   BAG address.
+     * @param tagSetter Will be called for each tag to set.
+     */
+    void bagToOsm(OdAddress address, BiConsumer<String, String> tagSetter);
+}

--- a/src/main/java/org/openstreetmap/josm/plugins/ods/bag/osm/build/address/converters/Generiek.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/ods/bag/osm/build/address/converters/Generiek.java
@@ -1,0 +1,48 @@
+package org.openstreetmap.josm.plugins.ods.bag.osm.build.address.converters;
+
+import org.openstreetmap.josm.plugins.ods.bag.osm.build.address.AddressConverter;
+import org.openstreetmap.josm.plugins.ods.domains.buildings.OdAddress;
+
+import java.util.function.BiConsumer;
+
+import static org.openstreetmap.josm.plugins.ods.bag.osm.build.address.AddressConversionAlgorithms.*;
+
+/**
+ * Generic conversion algorithm that should be the default fall-back.
+ */
+public class Generiek implements AddressConverter {
+    /**
+     * Check if this converter can be used for this address. As this is the catch-all converter, {@code true} is always
+     * returned.
+     *
+     * @param address BAG address.
+     * @return True, always.
+     */
+    @Override
+    public boolean isApplicable(OdAddress address) {
+        // Catch-all. Works for all Dutch addresses.
+        return true;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void bagToOsm(OdAddress address, BiConsumer<String, String> tagSetter) {
+        if (address.getStreetName() != null) {
+            tagSetter.accept(ADDR_STREET, address.getStreetName());
+        }
+        if (address.getFullHouseNumber() != null
+                && !address.getFullHouseNumber().isEmpty()
+                // Bug in formatHouseNumber causes a literal string "null" to be returned if there is no housenumber.
+                && !address.getFullHouseNumber().equals("null")) {
+            tagSetter.accept(ADDR_HOUSENUMBER, address.getFullHouseNumber());
+        }
+        if (address.getPostcode() != null) {
+            tagSetter.accept(ADDR_POSTCODE, address.getPostcode());
+        }
+        if (address.getCityName() != null) {
+            tagSetter.accept(ADDR_CITY, address.getCityName());
+        }
+    }
+}

--- a/src/main/java/org/openstreetmap/josm/plugins/ods/bag/osm/build/address/converters/Voorloopletter.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/ods/bag/osm/build/address/converters/Voorloopletter.java
@@ -1,0 +1,283 @@
+package org.openstreetmap.josm.plugins.ods.bag.osm.build.address.converters;
+
+import org.openstreetmap.josm.plugins.ods.bag.osm.build.address.AddressConverter;
+import org.openstreetmap.josm.plugins.ods.domains.buildings.OdAddress;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.function.BiConsumer;
+
+import static org.openstreetmap.josm.plugins.ods.bag.osm.build.address.AddressConversionAlgorithms.*;
+
+/**
+ * <p>
+ * The BAG database was built on the assumption that all house numbers in the Netherlands consisted of a numeric value,
+ * followed by an optional letter, followed by an optional alphanumeric extension. This assumption was wrong. A number
+ * of localities have house numbers that follow these conventions with one notable exception: they start with a letter.
+ * </p>
+ * <p>
+ * Because the BAG encodes the required house number field as an integer, a leading letter is not possible. To work
+ * around this limitation, the BAG engineers conceived of a hack that appended that letter to the street name instead.
+ * On a printed address label, this doesn't matter too much (house number <u>underlined</u> for emphasis):
+ * </p>
+ * <dl>
+ *     <dt>Local usage (signage etc.)</dt>
+ *     <dd>Dominee Sicco Tjadenstraat <u>C52</u></dd>
+ *     <dt>BAG-hack</dt>
+ *     <dd>Dominee Sicco Tjadenstraat C <u>52</u></dd>
+ * </dl>
+ * <p>
+ * The downside of this hack is that consumers of BAG data now have streets named &quot;Dominee Sicco Tjadenstraat
+ * C&quot, where in reality the street sign says &quot;Dominee Sicco Tjadenstraat&quot;; and house numbers that lack
+ * their leading letter, whereas on the houses themselves the sign includes it.
+ * </p>
+ * <p>
+ * OpenStreetMap has no such limitation, so this class reverses this hack for known postcodes. The list of postcodes
+ * can be extended, but care should be taken to include only those postcodes that contain addresses on streets that are
+ * applicable. It is fine to include postcodes that contain addresses on streets that do not end with a letter as
+ * well as those that do, but bear in mind that not every street that ends in a letter should be passed to this class
+ * (e.g., &quot;Hoofdstraat W&quot; in Winsum is literally called this on local signage).
+ * </p>
+ */
+public class Voorloopletter implements AddressConverter {
+    static final Set<String> applicablePostcodes4;
+    static final Set<String> applicablePostcodes6;
+
+    static {
+        // Add larger postcode areas by leading number here.
+        applicablePostcodes4 = new HashSet<>(Arrays.asList(
+
+                // Pekela; het Pekelder ABC.
+                // Zie ook: https://www.levenderfgoedgroningen.nl/alle-verhalen/het-pekelder-abc
+                "9663"
+
+        ));
+
+        // More localised postcode areas can be added here.
+        applicablePostcodes6 = new HashSet<>(Arrays.asList(
+
+                // Zinkweg, Nieuw-Beijerland. Drie adressen in Zinkweg liggen net in een andere
+                // gemeente. Zij hebben de voorloopletter 'N' (voor Nieuw-Beijerland). Het bedrijf dat
+                // op Zinkweg N4 zit gebruikt de voorloopletter ook letterlijk zo op bebording en website.
+                "3264LK",
+
+                // Langbroekerdijk, Langbroek. Voorloopletter (A of B) staat op de
+                // huisnummerbordjes.
+                "3947BA",
+                "3947BB",
+                "3947BC",
+                "3947BD",
+                "3947BE",
+                "3947BG",
+                "3947BH",
+                "3947BJ",
+                "3947BK",
+
+
+                // Graafjansdijk, Westdorpe (Terneuzen). Voorloopletter (A of B) staat op de
+                // huisnummerbordjes.
+                "4554AE",
+                "4554AG",
+                "4554AH",
+                "4554AJ",
+                "4554AK",
+                "4554AL",
+                "4554AM",
+                "4554CA",
+                "4554CB",
+                "4554CC",
+                "4554CD",
+                "4554LA",
+                "4554LB",
+                "4554LC",
+                "4554LD",
+                "4554LE",
+                "4554LG",
+
+
+                // Deken van Erpstraat en Meierij, Sint-Oedenrode. Flats uit 2007 in bestaande straten.
+                // Voorloopletters zijn gebruikt om adresruimte te creëren in
+                "5492DE",
+                "5492DG",
+                "5492DH",
+                "5492DJ",
+                "5492DK",
+                "5492DL",
+
+
+                // Adelbert van Scharnlaan, Maastricht. Een lange straat met flats met voorloopletter.
+                // (A t/m S). Boven de portieken van de flats staan de huisnummers die daar bij horen,
+                // met voorloopletter. Straatnaamborden spreken ook enkel van Adelbert van Scharnlaan
+                // (geen letter erachter).
+                "6226EC",
+                "6226ED",
+                "6226EE",
+                "6226EG",
+                "6226EH",
+                "6226EJ",
+                "6226EK",
+                "6226EL",
+                "6226EM",
+                "6226EN",
+                "6226EP",
+                "6226ER",
+                "6226ES",
+                "6226ET",
+                "6226EV",
+                "6226EW",
+                "6226EX",
+                "6226EZ",
+                "6226HT",
+                "6226HV",
+                "6226HW",
+                "6227CE",
+                "6227CG",
+                "6227CH",
+                "6227VE",
+                "6227VG",
+                "6227VH",
+
+
+                // Wethouder Vrankenstraat, Maastricht. Deze straat heeft naast gewone huisnummers
+                // één flat met voorloopletters aan het begin van de straat.
+                "6227CE",
+                "6227CG",
+                "6227CH",
+
+
+                // Burgemeester Kessensingel, Maastricht. Deze straat heeft naast gewone huisnummers
+                // drie flats ('A', 'B', 'C') met voorloopletters. Op de straatnaamborden bestaat
+                // alleen de Burgemeester Kessensingel zonder toevoeging.
+                "6227VE",
+                "6227VG",
+                "6227VH",
+
+
+                // Averbergen, Olst. Dit zijn (verzorgings)flats waar de vleugels een eigen letter
+                // hebben. De straat heet gewoon Averbergen.
+                "8121CD",
+                "8121CE",
+                "8121CG",
+                "8121CH",
+                "8121CJ",
+
+
+                // Recreatiewoningen aan de Beukenlaan in Oudemirdum.
+                // Huisnummers beginnen allen met 'Z' (valt op de huisnummerplaatjes te zien).
+                "8567HE",
+                "8567HG",
+
+
+                // Nieuwebildtzijl. Adressen hebben gehuchtnaam als 'straatnaam', maar een paar adressen
+                // (deze postcode) liggen net in een andere gemeente (Nieuwebildtzijl ligt in de Waadhoeke).
+                // Nu is dat Noardeast-Frsylân, maar dat was Ferwerderadiel. Vandaar de 'F' die deze
+                // huisnummers als voorloopletter hebben (valt op de huisnummerplaatjes te zien).
+                "9074PA",
+
+
+                // Bartlehiem. Adressen hebben gehuchtnaam als 'straatnaam', maar een paar adressen
+                // (deze postcode) liggen net in een andere gemeente (de rest van Bartlehiem ligt in
+                // Tytsjerksteradiel). Nu is dat Noardeast-Frsylân, maar dat was Ferwerderadiel. Vandaar
+                // de 'F' die deze huisnummers als voorloopletter hebben (valt op de huisnummerplaatjes te zien).
+                "9178GH",
+
+
+                // Recreatiepark Oosterduinen in Norg.
+                // Alle adressen hebben Oosterduinen (het terrein) als 'straatnaam'. Paden tussen de huisjes hebben
+                // eigen namen die niet in de adressen terugkeren.
+                // Zie ook: http://oosterduinen.nl/
+                "9331WB",
+                "9331WC",
+                "9331WD",
+                "9331WE",
+                "9331WG",
+                "9331WH",
+                "9331WK",
+
+
+                // Amerika, Een (Drenthe). Recreatiewoningen met een voorloopletter om binnen de adresruimte
+                // te passen.
+                "9342TN",
+
+
+                // Fivelkade Appingedam. De woonboten aan de kade hebben een voorloopletter 'W'. De huizen
+                // aan dezelfde straat niet. Zonder voorloopletter botsen de nummers.
+                "9901GE"
+        ));
+
+        // False positives: these streets look like they might be used to hide a voorloopletter, but
+        // are in fact valid street names. They are documented here to prevent contributors from wasting
+        // time hunting down these streets ending in a letter.
+
+        /*
+
+            2064KA
+                Zijkanaal C, Spaarndam. Vernoemd naar naastgelegen kanaal dat zo heet.
+
+            5521E*
+                Lindehof N, M, B, Z in Eersel. Letter hoort bij straatnaam.
+
+            6225CH
+                In de O, Maastricht. Straat heet gewoon zo.
+
+            7739PX
+                Kolonieweg O. Staat zo op straatnaambordjes. Vroeger zal deze weg in de naastgelegen gemeente
+                verder hebben gelopen, maar die lijkt hem hernoemd te hebben naar 'De Kolonie'.
+
+            8011VS
+                Kleine A, Zwolle. Letter hoort bij straatnaam.
+
+            9951A*
+                Winsum, Hoofdstraat O en Hoofdstraat W. O en W staan voor Obergum en Winsum, respectievelijk.
+
+            9711HV
+                Kleine der A, Groningen, de A is een gracht in Groningen.
+            9712A*
+                Hoge der A, Groningen, de A is een gracht in Groningen.
+            9718B*
+                Lage der A, Groningen, de A is een gracht in Groningen.
+
+         */
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isApplicable(OdAddress address) {
+        String postcode6 = address.getPostcode();
+        if (postcode6 == null) return false;
+
+        // The 1234 part of 1234AB.
+        String postcode4 = postcode6.substring(0, 4);
+
+        if (applicablePostcodes4.contains(postcode4) || applicablePostcodes6.contains(postcode6)) {
+            String street = address.getStreetName();
+            return street != null &&
+                    // Ignore addresses on streets that do not end in a single capital letter.
+                    street.matches(".+ [A-Z]") &&
+                    address.getFullHouseNumber() != null;
+        }
+
+        return false;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void bagToOsm(OdAddress address, BiConsumer<String, String> tagSetter) {
+        String street = address.getStreetName();
+        String letterPrefix = street.substring(street.length() - 1);
+        street = street.substring(0, street.length() - 2);
+
+        tagSetter.accept(ADDR_STREET, street);
+        tagSetter.accept(ADDR_HOUSENUMBER, letterPrefix + address.getFullHouseNumber());
+
+        tagSetter.accept(ADDR_POSTCODE, address.getPostcode());
+        if (address.getCityName() != null) {
+            tagSetter.accept(ADDR_CITY, address.getCityName());
+        }
+    }
+}

--- a/src/test/java/org/openstreetmap/josm/plugins/ods/bag/osm/build/address/AddressConversionAlgorithmsTest.java
+++ b/src/test/java/org/openstreetmap/josm/plugins/ods/bag/osm/build/address/AddressConversionAlgorithmsTest.java
@@ -1,0 +1,54 @@
+package org.openstreetmap.josm.plugins.ods.bag.osm.build.address;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.openstreetmap.josm.plugins.ods.bag.entity.BagOdAddress;
+import org.openstreetmap.josm.plugins.ods.domains.buildings.OdAddress;
+
+import java.util.function.BiConsumer;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+import static org.openstreetmap.josm.plugins.ods.bag.osm.build.address.AddressConversionAlgorithms.*;
+
+class AddressConversionAlgorithmsTest {
+    @Test
+    @SuppressWarnings("unchecked")
+    public void bagToOsmSimpleAddressTest() {
+        OdAddress address = new BagOdAddress();
+        address.setStreetName("Straat");
+        address.setFullHouseNumber("12");
+        address.setPostcode("1234AB");
+        address.setCityName("Stad");
+
+        BiConsumer<String, String> tagSetter = mock(BiConsumer.class);
+
+        AddressConversionAlgorithms.bagToOsm(address, tagSetter);
+
+        verify(tagSetter).accept(ADDR_STREET, "Straat");
+        verify(tagSetter).accept(ADDR_HOUSENUMBER, "12");
+        verify(tagSetter).accept(ADDR_POSTCODE, "1234AB");
+        verify(tagSetter).accept(ADDR_CITY, "Stad");
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void bagToOsmNullAddressTest() {
+        BiConsumer<String, String> tagSetter = mock(BiConsumer.class);
+
+        // Treat null address as no-op.
+        AddressConversionAlgorithms.bagToOsm(null, tagSetter);
+
+        verify(tagSetter, never()).accept(anyString(), anyString());
+    }
+
+    @Test
+    public void bagToOsmNullSetterTest() {
+        OdAddress address = new BagOdAddress();
+
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> AddressConversionAlgorithms.bagToOsm(address, null)
+        );
+    }
+}

--- a/src/test/java/org/openstreetmap/josm/plugins/ods/bag/osm/build/address/converters/GeneriekTest.java
+++ b/src/test/java/org/openstreetmap/josm/plugins/ods/bag/osm/build/address/converters/GeneriekTest.java
@@ -1,0 +1,60 @@
+package org.openstreetmap.josm.plugins.ods.bag.osm.build.address.converters;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.openstreetmap.josm.plugins.ods.bag.entity.BagOdAddress;
+import org.openstreetmap.josm.plugins.ods.bag.osm.build.address.AddressConversionAlgorithms;
+import org.openstreetmap.josm.plugins.ods.bag.osm.build.address.AddressConverter;
+import org.openstreetmap.josm.plugins.ods.domains.buildings.OdAddress;
+
+import java.util.function.BiConsumer;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+import static org.openstreetmap.josm.plugins.ods.bag.osm.build.address.AddressConversionAlgorithms.*;
+import static org.openstreetmap.josm.plugins.ods.bag.osm.build.address.AddressConversionAlgorithms.ADDR_CITY;
+
+class GeneriekTest {
+    AddressConverter converter;
+
+    @BeforeEach
+    public void setup() {
+        converter = new Generiek();
+    }
+
+    @Test
+    public void isApplicableTest() {
+        assertTrue(converter.isApplicable(mock(OdAddress.class)));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void bagToOsmTest() {
+        OdAddress address = new BagOdAddress();
+        address.setStreetName("Straat");
+        address.setFullHouseNumber("12");
+        address.setPostcode("1234AB");
+        address.setCityName("Stad");
+
+        BiConsumer<String, String> tagSetter = mock(BiConsumer.class);
+
+        converter.bagToOsm(address, tagSetter);
+
+        verify(tagSetter).accept(ADDR_STREET, "Straat");
+        verify(tagSetter).accept(ADDR_HOUSENUMBER, "12");
+        verify(tagSetter).accept(ADDR_POSTCODE, "1234AB");
+        verify(tagSetter).accept(ADDR_CITY, "Stad");
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void bagToOsmHandleNullsTest() {
+        OdAddress address = new BagOdAddress();
+
+        BiConsumer<String, String> tagSetter = mock(BiConsumer.class);
+
+        converter.bagToOsm(address, tagSetter);
+
+        verify(tagSetter, never()).accept(anyString(), anyString());
+    }
+}

--- a/src/test/java/org/openstreetmap/josm/plugins/ods/bag/osm/build/address/converters/VoorloopletterTest.java
+++ b/src/test/java/org/openstreetmap/josm/plugins/ods/bag/osm/build/address/converters/VoorloopletterTest.java
@@ -1,0 +1,86 @@
+package org.openstreetmap.josm.plugins.ods.bag.osm.build.address.converters;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.openstreetmap.josm.plugins.ods.bag.entity.BagOdAddress;
+import org.openstreetmap.josm.plugins.ods.bag.osm.build.address.AddressConverter;
+import org.openstreetmap.josm.plugins.ods.domains.buildings.OdAddress;
+
+import java.util.function.BiConsumer;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.openstreetmap.josm.plugins.ods.bag.osm.build.address.AddressConversionAlgorithms.*;
+
+class VoorloopletterTest {
+    AddressConverter converter;
+
+    @BeforeEach
+    public void setup() {
+        converter = new Voorloopletter();
+    }
+
+    @Test
+    public void ignoreGenericTest() {
+        OdAddress address = new BagOdAddress();
+        address.setStreetName("Straat");
+        address.setFullHouseNumber("12");
+        address.setPostcode("1234AB");
+        address.setCityName("Stad");
+
+        assertFalse(converter.isApplicable(address));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void pekelaTest() {
+        OdAddress address = new BagOdAddress();
+        address.setStreetName("Dominee Sicco Tjadenstraat C");
+        address.setFullHouseNumber("52");
+        address.setPostcode("9663RC");
+        address.setCityName("Nieuwe Pekela");
+
+        BiConsumer<String, String> tagSetter = mock(BiConsumer.class);
+
+        assertTrue(converter.isApplicable(address));
+
+        converter.bagToOsm(address, tagSetter);
+
+        verify(tagSetter).accept(ADDR_STREET, "Dominee Sicco Tjadenstraat");
+        verify(tagSetter).accept(ADDR_HOUSENUMBER, "C52");
+        verify(tagSetter).accept(ADDR_POSTCODE, "9663RC");
+        verify(tagSetter).accept(ADDR_CITY, "Nieuwe Pekela");
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void pekelaNormalTest() {
+        OdAddress address = new BagOdAddress();
+        address.setStreetName("Eigenhaardstraat");
+        address.setFullHouseNumber("4");
+        address.setPostcode("9663RH");
+        address.setCityName("Nieuwe Pekela");
+
+        assertFalse(converter.isApplicable(address));
+    }
+
+    @Test
+    public void notationTest() {
+        // Make sure all postcodes entered are valid.
+        for (String pp4 : Voorloopletter.applicablePostcodes4) {
+            assertTrue(
+                    pp4.matches("[1-9][0-9]{3}"),
+                    "Postcodes in this set must contain only the first four numbers."
+            );
+        }
+
+        for (String pp6 : Voorloopletter.applicablePostcodes6) {
+            assertTrue(
+                    pp6.matches("[1-9][0-9]{3}[A-Z]{2}"),
+                    "Postcodes in this set must be valid Dutch postcodes."
+            );
+        }
+    }
+}


### PR DESCRIPTION
De BAG is ontworpen met een aanname dat huisnummers (zonder extensie) altijd numeriek zijn. Het huisnummerveld is daardoor een integer. Deze aanname klopt helaas niet ([voorbeeld: Pekela staat hier bekend om](https://www.google.com/maps/@53.0735309,6.9614038,3a,15y,286.9h,90.71t/data=!3m6!1e1!3m4!1shp9qL527LBZqTvibvbZhIw!2e0!7i13312!8i6656)), waardoor er een manier gezocht werd om huisnummers met een voorloopletter toch op te kunnen slaan.

Het gekozen trucje plakt de voorloopletter achter de straatnaam. Zo is huisnummer `C53` aan de _Dominee Sicco Tjadenstraat_ in Nieuwe Pekela opgeslagen als:

* Straatnaam: _Ds. Sicco Tjadenstraat C_
* Huisnummer: `53`

In OpenStreetMap kopiëren we deze fout nu een-op-een. Gelukkig is dat niet nodig in OSM, omdat het huisnummerveld gewoon een vrije string is.

Deze PR breidt de BAG plugin uit met een manier om bij selecte postcodes de BAG-hack weer terug te draaien. Zo krijgen we in OSM de adressen die daadwerkelijk bestaan ter plekke.

@gidema Dit is eerst even een preview voor jou om te polsen hoe jij tegenover deze methode staat. Ik wil het probleem van de voorloopletter op het Nederlandstalige OSM-forum ter discussie stellen voordat we adressen gaan omzetten.

Ik ben er in de opzet van deze code vanuit gegaan dat er meer uitzonderingen zijn waar code voor geschreven kan worden. Dat verklaart de opzet van `AddressConversionAlgorithms`.

De code is gedekt door unittests, en door mij getest in JOSM (zonder uploads uit te voeren).