### PR TITLE
Fix enum comparison

### DIFF
--- a/src/main/java/org/openstreetmap/josm/plugins/ods/bag/osm/build/BagBuildingEntityPrimitiveBuilder.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/ods/bag/osm/build/BagBuildingEntityPrimitiveBuilder.java
@@ -17,7 +17,7 @@ public class BagBuildingEntityPrimitiveBuilder extends BagEntityPrimitiveBuilder
     public void createPrimitive(OdBuilding building) {
         // Ignore buildings with status "Bouwvergunning verleend"
         // Make an exception for buildings that already exist in OSM. In that case, the building permit is for reconstruction
-        if ("Bouwvergunning verleend".equals(building.getStatus())
+        if (building.getStatus() == EntityStatus.PLANNED
                 && building.getMatch() == null) {
             return;
         }
@@ -37,7 +37,7 @@ public class BagBuildingEntityPrimitiveBuilder extends BagEntityPrimitiveBuilder
         if (building.getStartDate() != null) {
             tags.put("start_date", building.getStartDate());
         }
-        if ("Sloopvergunning verleend".equals(building.getStatus())) {
+        if (building.getStatus() == EntityStatus.REMOVAL_DUE) {
             tags.put("note", "Sloopvergunning verleend");
         }
         String type = "yes";
@@ -81,8 +81,8 @@ public class BagBuildingEntityPrimitiveBuilder extends BagEntityPrimitiveBuilder
             break;
         }
 
-        if (building.getStatus().equals(EntityStatus.CONSTRUCTION) ||
-                building.getStatus().equals(EntityStatus.PLANNED)) {
+        if (building.getStatus() == EntityStatus.CONSTRUCTION ||
+                building.getStatus() == EntityStatus.PLANNED) {
             tags.put("building", "construction");
             tags.put("construction", type);
         }


### PR DESCRIPTION
Ik zag bij het werken aan de voorlooplettercode twee bugs in deze code. String wordt met BuildingStatus vergeleken, en zal altijd `false` teruggeven. Dat zal met een refactor eens gebeurd zijn denk ik?

Enums mag je met `==` vergelijken in Java, omdat het singleton-instanties zijn.